### PR TITLE
Tsf 3553/sokedropdown forbedringer

### DIFF
--- a/src/client/app/sharedComponents/SelectCheckbox.tsx
+++ b/src/client/app/sharedComponents/SelectCheckbox.tsx
@@ -13,13 +13,17 @@ interface Props {
 
 const SelectCheckbox: React.FC<Props> = ({ value, label, onClick, numberOfItems, isChecked }) => (
 	<div className={styles.wrapper}>
-		<Checkbox onClick={() => onClick(value)} value={value} checked={isChecked}>
-			{label}
-			<div className={styles.wrapperRight}>
-				{numberOfItems ? <div className={styles.numberBubble}>{numberOfItems}</div> : null}
-				<Next className={isChecked ? styles.chevronIconChecked : ''} />
+		<div className="flex flex-row">
+			<Checkbox className="flex-shrink-0" onClick={() => onClick(value)} value={value} checked={isChecked}>
+				{label}
+			</Checkbox>
+			<div className="flex-grow">
+				<div className="flex mt-3 float-right">
+					{numberOfItems ? <div className={styles.numberBubble}>{numberOfItems}</div> : null}
+					<Next className={isChecked ? styles.chevronIconChecked : ''} />
+				</div>
 			</div>
-		</Checkbox>
+		</div>
 	</div>
 );
 

--- a/src/client/app/sharedComponents/SelectCheckbox.tsx
+++ b/src/client/app/sharedComponents/SelectCheckbox.tsx
@@ -7,11 +7,21 @@ interface Props {
 	value: string;
 	label: string;
 	onClick: (suggestionGroup: string) => void;
+	toggleGroupOpen: (suggestionGroup: string) => void;
 	numberOfItems: number;
 	isChecked: boolean;
+	isOpen: boolean;
 }
 
-const SelectCheckbox: React.FC<Props> = ({ value, label, onClick, numberOfItems, isChecked }) => (
+const SelectCheckbox: React.FC<Props> = ({
+	value,
+	label,
+	onClick,
+	numberOfItems,
+	isChecked,
+	toggleGroupOpen,
+	isOpen,
+}) => (
 	<div className={styles.wrapper}>
 		<div className="flex flex-row">
 			<Checkbox className="flex-shrink-0" onClick={() => onClick(value)} value={value} checked={isChecked}>
@@ -20,7 +30,12 @@ const SelectCheckbox: React.FC<Props> = ({ value, label, onClick, numberOfItems,
 			<div className="flex-grow">
 				<div className="flex mt-3 float-right">
 					{numberOfItems ? <div className={styles.numberBubble}>{numberOfItems}</div> : null}
-					<Next className={isChecked ? styles.chevronIconChecked : ''} />
+					<Next
+						width="1.5em"
+						height="1.5em"
+						onClick={() => toggleGroupOpen(value)}
+						className={`${isOpen ? styles.chevronIconChecked : ''} cursor-pointer`}
+					/>
 				</div>
 			</div>
 		</div>

--- a/src/client/app/sharedComponents/searchWithDropdown/SearchWithDropdown.tsx
+++ b/src/client/app/sharedComponents/searchWithDropdown/SearchWithDropdown.tsx
@@ -107,23 +107,31 @@ const SearchWithDropdown: React.FC<SearchWithDropdownProps> = (props) => {
 	};
 
 	const deselectSuggestionGroupAndSubValues = (suggestionGroup: string) => {
-		setOpenSuggestionGroups(openSuggestionGroups.filter((s) => s !== suggestionGroup));
 		setSelectedSuggestionValues(
 			selectedSuggestionValues.filter((suggestionValue) => getSuggestion(suggestionValue).group !== suggestionGroup),
 		);
 	};
 
 	const selectSuggestionGroupAndSubValues = (suggestionGroup: string) => {
-		setOpenSuggestionGroups([...openSuggestionGroups, suggestionGroup]);
 		const relevantSuggestionValues = suggestions.filter((s) => s.group === suggestionGroup).map((s) => s.value);
 		setSelectedSuggestionValues([...selectedSuggestionValues, ...relevantSuggestionValues]);
 	};
 
-	const handleSuggestionGroupToggle = (suggestionGroup: string) => {
-		if (openSuggestionGroups.includes(suggestionGroup)) {
+	const toggleGroupSelectionValues = (suggestionGroup: string) => {
+		const isGroupSelected = selectedSuggestionValues.some(
+			(suggestionValue) => getSuggestion(suggestionValue).group === suggestionGroup,
+		);
+		if (isGroupSelected) {
 			deselectSuggestionGroupAndSubValues(suggestionGroup);
 		} else {
 			selectSuggestionGroupAndSubValues(suggestionGroup);
+		}
+	};
+
+	const toggleGroupOpen = (suggestionGroup: string) => {
+		if (openSuggestionGroups.includes(suggestionGroup)) {
+			setOpenSuggestionGroups(openSuggestionGroups.filter((s) => s !== suggestionGroup));
+		} else {
 			setOpenSuggestionGroups([...openSuggestionGroups, suggestionGroup]);
 		}
 	};
@@ -163,7 +171,8 @@ const SearchWithDropdown: React.FC<SearchWithDropdownProps> = (props) => {
 						showFilteredSuggestionsOnly={showFilteredSuggestionsOnly}
 						selectedSuggestionValues={selectedSuggestionValues}
 						onSelect={onSelect}
-						handleSuggestionGroupToggle={handleSuggestionGroupToggle}
+						toggleGroupSelectionValues={toggleGroupSelectionValues}
+						toggleGroupOpen={toggleGroupOpen}
 						updateSelection={updateSelection}
 						addButtonText={addButtonText}
 						openSuggestionGroups={openSuggestionGroups}

--- a/src/client/app/sharedComponents/searchWithDropdown/SuggestionList.tsx
+++ b/src/client/app/sharedComponents/searchWithDropdown/SuggestionList.tsx
@@ -12,59 +12,99 @@ const SuggestionList = ({
 	showFilteredSuggestionsOnly,
 	selectedSuggestionValues,
 	onSelect,
-	handleSuggestionGroupToggle,
+	toggleGroupOpen,
+	toggleGroupSelectionValues,
 	updateSelection,
 	addButtonText,
 	openSuggestionGroups,
 	setIsPopoverOpen,
 	getSuggestion,
-}) => (
-	<ComboboxPopover className={styles.suggestionPopover} portal={false}>
-		{groups?.length > 0 && (
-			<>
-				<Heading className={styles.listHeading} level="3" size="xsmall">
-					Grupper
-				</Heading>
+}) => {
+	const groupHasSelectedSuggestions = (group) =>
+		selectedSuggestionValues.some((suggestionValue) => getSuggestion(suggestionValue).group === group);
+
+	const groupIsOpen = (group) => openSuggestionGroups.includes(group);
+	return (
+		<ComboboxPopover className={styles.suggestionPopover} portal={false}>
+			{groups?.length > 0 && (
+				<>
+					<Heading className={styles.listHeading} level="3" size="xsmall">
+						Grupper
+					</Heading>
+					<fieldset className={styles.fieldset}>
+						<legend className="navds-sr-only">{heading}</legend>
+						<ComboboxList className={styles.list}>
+							{!showFilteredSuggestionsOnly &&
+								groups
+									.filter((group) => filteredSuggestions.some((suggestion) => suggestion.group === group))
+									.map((group) => {
+										const suggestionsInThisGroup = suggestions.filter((suggestion) => suggestion.group === group);
+										const numberOfSelectedItemsInGroup = selectedSuggestionValues.filter(
+											(suggestionValue) => getSuggestion(suggestionValue).group === group,
+										).length;
+
+										return (
+											<li key={group}>
+												<SelectCheckbox
+													value={group}
+													label={group}
+													onClick={(suggestionGroup) => toggleGroupSelectionValues(suggestionGroup)}
+													toggleGroupOpen={(suggestionGroup) => toggleGroupOpen(suggestionGroup)}
+													numberOfItems={numberOfSelectedItemsInGroup}
+													isChecked={groupHasSelectedSuggestions(group)}
+													isOpen={groupIsOpen(group)}
+												/>
+												{openSuggestionGroups.includes(group) && (
+													<ul>
+														{suggestionsInThisGroup.map((suggestion) => (
+															<li key={suggestion.value} className={styles.suggestionSubgroup}>
+																<Checkbox
+																	className={styles.suggestionCheckbox}
+																	value={suggestion.value}
+																	onClick={() => onSelect(suggestion.value)}
+																	checked={selectedSuggestionValues.includes(suggestion.value)}
+																>
+																	{suggestion.label}
+																</Checkbox>
+															</li>
+														))}
+													</ul>
+												)}
+											</li>
+										);
+									})}
+							{showFilteredSuggestionsOnly &&
+								filteredSuggestions.map((suggestion) => (
+									<Checkbox
+										key={suggestion.value}
+										className={styles.suggestionCheckbox}
+										value={suggestion.value}
+										onClick={() => onSelect(suggestion.value)}
+										checked={selectedSuggestionValues.includes(suggestion.value)}
+									>
+										{suggestion.label}
+									</Checkbox>
+								))}
+						</ComboboxList>
+					</fieldset>
+				</>
+			)}
+			{!groups && (
 				<fieldset className={styles.fieldset}>
 					<legend className="navds-sr-only">{heading}</legend>
 					<ComboboxList className={styles.list}>
 						{!showFilteredSuggestionsOnly &&
-							groups
-								.filter((group) => filteredSuggestions.some((suggestion) => suggestion.group === group))
-								.map((group) => {
-									const suggestionsInThisGroup = suggestions.filter((suggestion) => suggestion.group === group);
-									const numberOfSelectedItemsInGroup = selectedSuggestionValues.filter(
-										(suggestionValue) => getSuggestion(suggestionValue).group === group,
-									).length;
-
-									return (
-										<li key={group}>
-											<SelectCheckbox
-												value={group}
-												label={group}
-												onClick={(suggestionGroup) => handleSuggestionGroupToggle(suggestionGroup)}
-												numberOfItems={numberOfSelectedItemsInGroup}
-												isChecked={openSuggestionGroups.includes(group)}
-											/>
-											{openSuggestionGroups.includes(group) && (
-												<ul>
-													{suggestionsInThisGroup.map((suggestion) => (
-														<li key={suggestion.value} className={styles.suggestionSubgroup}>
-															<Checkbox
-																className={styles.suggestionCheckbox}
-																value={suggestion.value}
-																onClick={() => onSelect(suggestion.value)}
-																checked={selectedSuggestionValues.includes(suggestion.value)}
-															>
-																{suggestion.label}
-															</Checkbox>
-														</li>
-													))}
-												</ul>
-											)}
-										</li>
-									);
-								})}
+							suggestions.map((suggestion) => (
+								<Checkbox
+									key={suggestion.value}
+									className={styles.suggestionCheckbox}
+									value={suggestion.value}
+									onClick={() => onSelect(suggestion.value)}
+									checked={selectedSuggestionValues.includes(suggestion.value)}
+								>
+									{suggestion.label}
+								</Checkbox>
+							))}
 						{showFilteredSuggestionsOnly &&
 							filteredSuggestions.map((suggestion) => (
 								<Checkbox
@@ -79,53 +119,22 @@ const SuggestionList = ({
 							))}
 					</ComboboxList>
 				</fieldset>
-			</>
-		)}
-		{!groups && (
-			<fieldset className={styles.fieldset}>
-				<legend className="navds-sr-only">{heading}</legend>
-				<ComboboxList className={styles.list}>
-					{!showFilteredSuggestionsOnly &&
-						suggestions.map((suggestion) => (
-							<Checkbox
-								key={suggestion.value}
-								className={styles.suggestionCheckbox}
-								value={suggestion.value}
-								onClick={() => onSelect(suggestion.value)}
-								checked={selectedSuggestionValues.includes(suggestion.value)}
-							>
-								{suggestion.label}
-							</Checkbox>
-						))}
-					{showFilteredSuggestionsOnly &&
-						filteredSuggestions.map((suggestion) => (
-							<Checkbox
-								key={suggestion.value}
-								className={styles.suggestionCheckbox}
-								value={suggestion.value}
-								onClick={() => onSelect(suggestion.value)}
-								checked={selectedSuggestionValues.includes(suggestion.value)}
-							>
-								{suggestion.label}
-							</Checkbox>
-						))}
-				</ComboboxList>
-			</fieldset>
-		)}
-		<p className={styles.popoverButtonWrapper}>
-			<Button
-				onClick={() => {
-					updateSelection(selectedSuggestionValues);
-					setIsPopoverOpen(false);
-				}}
-				variant="primary"
-				size="medium"
-				type="button"
-			>
-				{addButtonText}
-			</Button>
-		</p>
-	</ComboboxPopover>
-);
+			)}
+			<p className={styles.popoverButtonWrapper}>
+				<Button
+					onClick={() => {
+						updateSelection(selectedSuggestionValues);
+						setIsPopoverOpen(false);
+					}}
+					variant="primary"
+					size="medium"
+					type="button"
+				>
+					{addButtonText}
+				</Button>
+			</p>
+		</ComboboxPopover>
+	);
+};
 
 export default SuggestionList;

--- a/src/client/app/sharedComponents/selectCheckbox.css
+++ b/src/client/app/sharedComponents/selectCheckbox.css
@@ -7,12 +7,7 @@
 	display: flex;
 	justify-content: space-between;
 }
-.wrapper :global(.navds-checkbox__content) {
-	width: 100%;
-}
-.wrapper :global(.navds-checkbox) {
-	width: 100%;
-}
+
 .chevronIconChecked {
 	transform: rotate(90deg);
 }


### PR DESCRIPTION
Gjør at man kan ekspandere grupper uten at alle valgene i gruppen blir selected. Hvis man kun skal ha et av elementene i gruppen måtte man toggle av alle andre