### PR TITLE
onErrorCallback når reservasjon i FagsakSearchIndex feiler

### DIFF
--- a/src/client/app/saksbehandler/fagsakSearch/FagsakSearchIndex.tsx
+++ b/src/client/app/saksbehandler/fagsakSearch/FagsakSearchIndex.tsx
@@ -75,7 +75,7 @@ const FagsakSearchIndex: FunctionComponent<OwnProps> = ({ k9sakUrl, k9punsjUrl }
 		}
 	};
 
-	const velgFagsakOperasjoner = (oppgave: Oppgave, reserver: boolean) => {
+	const velgFagsakOperasjoner = (oppgave: Oppgave, reserver: boolean, onError: (errorString: string) => void) => {
 		if (oppgave.status.erReservert && !oppgave.status.erReservertAvInnloggetBruker) {
 			setReservertOppgave(oppgave);
 			setReservertAvAnnenSaksbehandler(true);
@@ -89,8 +89,8 @@ const FagsakSearchIndex: FunctionComponent<OwnProps> = ({ k9sakUrl, k9punsjUrl }
 			leggTilBehandletOppgave(oppgave.oppgaveNøkkel);
 			goToFagsakEllerApneModal(oppgave);
 		} else if (reserver && kanReservere) {
-			reserverOppgave({ oppgaveId: oppgave.eksternId, oppgaveNøkkel: oppgave.oppgaveNøkkel }).then(
-				(nyOppgaveStatus) => {
+			reserverOppgave({ oppgaveId: oppgave.eksternId, oppgaveNøkkel: oppgave.oppgaveNøkkel })
+				.then((nyOppgaveStatus) => {
 					if (nyOppgaveStatus.kanOverstyres) {
 						setValgtOppgave(oppgave);
 						setValgtOppgaveStatus(nyOppgaveStatus);
@@ -99,8 +99,12 @@ const FagsakSearchIndex: FunctionComponent<OwnProps> = ({ k9sakUrl, k9punsjUrl }
 						leggTilBehandletOppgave(oppgave.oppgaveNøkkel);
 						goToFagsak(oppgave);
 					}
-				},
-			);
+				})
+				.catch((e) => {
+					if (typeof onError === 'function') {
+						onError(e.message);
+					}
+				});
 		} else if (!kanReservere) {
 			leggTilBehandletOppgave(oppgave.oppgaveNøkkel);
 			goToFagsak(oppgave);

--- a/src/client/app/saksbehandler/fagsakSearch/components/FagsakList.tsx
+++ b/src/client/app/saksbehandler/fagsakSearch/components/FagsakList.tsx
@@ -8,7 +8,6 @@ import { RestApiGlobalStatePathsKeys } from 'api/k9LosApi';
 import useGlobalStateRestApiData from 'api/rest-api-hooks/src/global-data/useGlobalStateRestApiData';
 import AlleKodeverk from 'kodeverk/alleKodeverkTsType';
 import kodeverkTyper from 'kodeverk/kodeverkTyper';
-import KommentarMedMerknad from 'saksbehandler/components/KommentarMedMerknad';
 import Oppgave from 'saksbehandler/oppgaveTsType';
 import Table from 'sharedComponents/Table';
 import TableColumn from 'sharedComponents/TableColumn';
@@ -31,7 +30,7 @@ const headerTextCodes = [
 
 interface OwnProps {
 	fagsakOppgaver: Oppgave[];
-	selectOppgaveCallback: (oppgave: Oppgave, skalReservere: boolean) => void;
+	selectOppgaveCallback: (oppgave: Oppgave, skalReservere: boolean, onError?: (errorString: string) => void) => void;
 	oppgaveSoktForViaQueryErAlleredeReservert: Oppgave | null;
 }
 
@@ -48,6 +47,7 @@ const FagsakList: FunctionComponent<OwnProps> = ({
 	const [visReserverOppgaveModal, setVisReserverOppgaveModal] = useState(false);
 	const [visOppgavePåVentModel, setVisOppgavePåVentModel] = useState(false);
 	const [valgtOppgave, setValgtOppgave] = useState<Oppgave>(null);
+	const [reservasjonErrorMessage, setReservasjonErrorMessage] = useState<string>('');
 
 	const { kanReservere } = useGlobalStateRestApiData<NavAnsatt>(RestApiGlobalStatePathsKeys.NAV_ANSATT);
 	const alleKodeverk: AlleKodeverk = useGlobalStateRestApiData(RestApiGlobalStatePathsKeys.KODEVERK);
@@ -83,8 +83,7 @@ const FagsakList: FunctionComponent<OwnProps> = ({
 	}, [oppgaveSoktForViaQueryErAlleredeReservert]);
 
 	const onSubmit = () => {
-		setVisReserverOppgaveModal(false);
-		selectOppgaveCallback(valgtOppgave, true);
+		selectOppgaveCallback(valgtOppgave, true, setReservasjonErrorMessage);
 	};
 
 	const onCancel = () => {
@@ -156,7 +155,7 @@ const FagsakList: FunctionComponent<OwnProps> = ({
 						valgmulighetA: 'Åpne',
 						valgmulighetB: oppgavePåVentMulighetBTekst,
 						formattedMessageId: 'OppgavePåVentModal.OppgavePåVent',
-						values: { dato: valgtOppgave.behandlingsfrist.substring(0, 10).replaceAll('-', '.') },
+						values: { dato: valgtOppgave.behandlingsfrist.substring(0, 10).replace(/-/g, '.') },
 					}}
 					ikonUrl={timeglassUrl}
 					ikonAlt="Timeglass"

--- a/src/client/app/saksbehandler/fagsakSearch/components/FagsakSearch.tsx
+++ b/src/client/app/saksbehandler/fagsakSearch/components/FagsakSearch.tsx
@@ -15,7 +15,7 @@ interface OwnProps {
 	resultat: SokeResultat;
 	searchFagsakCallback: ({ searchString, skalReservere }: { searchString: string; skalReservere: boolean }) => void;
 	searchResultReceived: boolean;
-	selectOppgaveCallback: (oppgave: Oppgave, reserver: boolean) => void;
+	selectOppgaveCallback: (oppgave: Oppgave, reserver: boolean, onError?: (errorMessage: string) => void) => void;
 	searchStarted: boolean;
 	searchResultAccessDenied?: {
 		feilmelding?: string;


### PR DESCRIPTION
Bakgrunn:
Får 403 når man prøver å reservere beslutteroppgave i samme sak som saksbehandler selv har behandlet. Feiler i stillhet uten at bruker blir opplyst om feilen.

Løsning:
Vise feilmelding fra backend dersom vi får en error på dette kallet