### PR TITLE
Skjuler reserverte oppgaver som ikke er åpne

### DIFF
--- a/src/client/app/saksbehandler/behandlingskoer/ReservasjonV3Dto.ts
+++ b/src/client/app/saksbehandler/behandlingskoer/ReservasjonV3Dto.ts
@@ -1,4 +1,4 @@
-import OppgaveV3 from 'types/OppgaveV3';
+import OppgaveV3, { OppgavestatusV3 } from 'types/OppgaveV3';
 import Oppgave from 'saksbehandler/oppgaveTsType';
 import { OppgaveNøkkel } from 'types/OppgaveNøkkel';
 
@@ -38,12 +38,14 @@ export function mapReservasjonV3Array(reservasjonV3Array: ReservasjonV3[]): Mapp
 				},
 			];
 		}
-		return reservasjon.reserverteV3Oppgaver.map(
-			(oppgave): MappedReservasjon => ({
-				...(oppgave as MappedReservasjon),
-				...pickReservasjonProperties(reservasjon),
-			}),
-		);
+		return reservasjon.reserverteV3Oppgaver
+			.filter((v) => v.oppgavestatus === OppgavestatusV3.AAPEN)
+			.map(
+				(oppgave): MappedReservasjon => ({
+					...(oppgave as MappedReservasjon),
+					...pickReservasjonProperties(reservasjon),
+				}),
+			);
 	});
 }
 

--- a/src/client/app/saksbehandler/behandlingskoer/components/oppgavetabeller/ReserverteOppgaverTabell.tsx
+++ b/src/client/app/saksbehandler/behandlingskoer/components/oppgavetabeller/ReserverteOppgaverTabell.tsx
@@ -11,6 +11,7 @@ import { Element, Normaltekst } from 'nav-frontend-typografi';
 import React, { FunctionComponent, useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useQueryClient } from 'react-query';
+import { OppgavestatusV3 } from 'types/OppgaveV3';
 import ReservasjonV3 from 'saksbehandler/behandlingskoer/ReservasjonV3Dto';
 import { getHeaderCodes } from 'saksbehandler/behandlingskoer/components/oppgavetabeller/oppgavetabellerfelles';
 import Oppgave from 'saksbehandler/oppgaveTsType';
@@ -70,8 +71,11 @@ const ReserverteOppgaverTabell: FunctionComponent<OwnProps> = ({ apneOppgave, gj
 		if (reservasjon.reservertOppgaveV1Dto) {
 			return 1;
 		}
-		if (reservasjon.reserverteV3Oppgaver.length > 0) {
-			return reservasjon.reserverteV3Oppgaver.length;
+		const v3OppgaverSomSkalVises = reservasjon.reserverteV3Oppgaver.filter(
+			(v) => v.oppgavestatus === OppgavestatusV3.AAPEN,
+		);
+		if (v3OppgaverSomSkalVises.length > 0) {
+			return v3OppgaverSomSkalVises.length;
 		}
 		return 0;
 	};
@@ -145,18 +149,20 @@ const ReserverteOppgaverTabell: FunctionComponent<OwnProps> = ({ apneOppgave, gj
 									ref={ref}
 								/>
 							) : (
-								reservasjon.reserverteV3Oppgaver?.map((oppgave) => (
-									<ReservertOppgaveRadV3
-										key={oppgave.oppgaveNøkkel.oppgaveEksternId}
-										oppgave={oppgave}
-										reservasjon={reservasjon}
-										forlengOppgaveReservasjonFn={forlengOppgaveReservasjonFn}
-										valgtOppgaveId={valgtOppgaveId}
-										setValgtOppgaveId={setValgtOppgaveId}
-										gjelderHastesaker={gjelderHastesaker}
-										ref={ref}
-									/>
-								))
+								reservasjon.reserverteV3Oppgaver
+									?.filter((v) => v.oppgavestatus === OppgavestatusV3.AAPEN)
+									.map((oppgave) => (
+										<ReservertOppgaveRadV3
+											key={oppgave.oppgaveNøkkel.oppgaveEksternId}
+											oppgave={oppgave}
+											reservasjon={reservasjon}
+											forlengOppgaveReservasjonFn={forlengOppgaveReservasjonFn}
+											valgtOppgaveId={valgtOppgaveId}
+											setValgtOppgaveId={setValgtOppgaveId}
+											gjelderHastesaker={gjelderHastesaker}
+											ref={ref}
+										/>
+									))
 							),
 						)}
 					</Table.Body>

--- a/src/client/app/types/OppgaveV3.ts
+++ b/src/client/app/types/OppgaveV3.ts
@@ -1,16 +1,21 @@
 import KodeverkMedNavn from 'kodeverk/kodeverkMedNavnTsType';
-import { OppgaveStatus } from '../saksbehandler/oppgaveStatusTsType';
 import { OppgaveNøkkel } from './OppgaveNøkkel';
 
 type OppgaveV3 = {
 	søkersNavn: string;
 	søkersPersonnr: string;
-	saksnummer: string;
-	journalpostId: string;
-	oppgavebehandlingsUrl: string;
-	oppgavestatus: OppgaveStatus;
 	behandlingstype: KodeverkMedNavn;
+	saksnummer: string;
 	oppgaveNøkkel: OppgaveNøkkel;
+	journalpostId: string;
+	oppgavestatus: OppgavestatusV3;
+	oppgavebehandlingsUrl: string;
 };
+
+export enum OppgavestatusV3 {
+	AAPEN = 'AAPEN',
+	VENTER = 'VENTER',
+	LUKKET = 'LUKKET',
+}
 
 export default OppgaveV3;


### PR DESCRIPTION
Bakgrunn:

I V3-modellen kan en reservasjon ha flere oppgaver. Når saker er tilknyttet hverandre vil begge bli reservert på samme saksbehandler. Og i disse tilfellene kan det være at f.eks mors sak åpne, mens fars sak venter på inntektsmelding. Begge disse LOS-oppgavene vil dukke opp i reservasjoner, men vi ønsker ikke at oppgaver som er på vent skal dukke opp i reservasjoner.

Løsning:
Skjuler oppgaver med saker som er på vent i frontend. Både i saksbehandlers reservasjoner og i avdelingsleders oversikt over reservasjoner