### PR TITLE
henter antall fra eget api i køoversikt

### DIFF
--- a/src/client/app/types/OppgavekøV3Type.ts
+++ b/src/client/app/types/OppgavekøV3Type.ts
@@ -15,7 +15,6 @@ export interface OppgavekøV3 extends OppgavekøV3Enkel {
 export interface OppgavekøV3Enkel {
 	id: string;
 	tittel: string;
-	antallOppgaver: number,
 	antallSaksbehandlere: number;
 	sistEndret: string | null;
 }


### PR DESCRIPTION
Bakgrunn: Noe ytelsesproblemer ved at antall oppgaver følger med på alle køene i køoversikten. Avdelingsleder må vente lenge for at alle køene skal bli hentet ut

Løsning: Hente antall oppgaver i separate kall slik at skjermbildet kanskje populeres litt fortere