### PR TITLE
Fikser bug ved sletting av saksbehandler

### DIFF
--- a/src/client/app/api/apiPaths.ts
+++ b/src/client/app/api/apiPaths.ts
@@ -45,6 +45,7 @@ const apiPaths = {
 	saksbehandlerReservasjoner: '/api/k9-los-api/saksbehandler/oppgaver/reserverte',
 	saksbehandlereIOppgaveko: '/api/k9-los-api/saksbehandler/oppgaveko/saksbehandlere',
 	slettOppgaveko: '/api/k9-los-api/ny-oppgavestyring/ko/',
+	slettSaksbehandler: '/api/k9-los-api/avdelingsleder/saksbehandlere/slett',
 	sok: '/api/k9-los-api/fagsak/sok',
 	sokV3: '/api/k9-los-api/ny-oppgavestyring/sok',
 	validerQuery: '/api/k9-los-api/ny-oppgavestyring/oppgave/validate',

--- a/src/client/app/api/queries/avdelingslederQueries.ts
+++ b/src/client/app/api/queries/avdelingslederQueries.ts
@@ -1,8 +1,24 @@
 import { UseQueryOptions, useMutation, useQuery, useQueryClient } from 'react-query';
 import apiPaths from 'api/apiPaths';
+import { Saksbehandler } from 'avdelingsleder/bemanning/saksbehandlerTsType';
 import Reservasjon from 'avdelingsleder/reservasjoner/reservasjonTsType';
 import { OppgavekøV3, OppgavekøV3Enkel, OppgavekøerV3 } from 'types/OppgavekøV3Type';
 import { axiosInstance } from 'utils/reactQueryConfig';
+
+export const useHentSaksbehandlereAvdelingsleder = () =>
+	useQuery<Saksbehandler[], unknown, Saksbehandler[]>({
+		queryKey: [apiPaths.hentSaksbehandlereAvdelingsleder],
+		staleTime: 1000,
+	});
+
+export const useSlettSaksbehandler = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (data: { epost: string }) => axiosInstance.post(apiPaths.slettSaksbehandler, data),
+		onSuccess: () => queryClient.invalidateQueries(apiPaths.hentSaksbehandlereAvdelingsleder),
+	});
+};
 
 // eslint-disable-next-line import/prefer-default-export
 export const useAlleKoer = (options = {}) =>

--- a/src/client/app/api/queries/avdelingslederQueries.ts
+++ b/src/client/app/api/queries/avdelingslederQueries.ts
@@ -8,7 +8,7 @@ import { axiosInstance } from 'utils/reactQueryConfig';
 export const useHentSaksbehandlereAvdelingsleder = () =>
 	useQuery<Saksbehandler[], unknown, Saksbehandler[]>({
 		queryKey: [apiPaths.hentSaksbehandlereAvdelingsleder],
-		staleTime: 1000,
+		staleTime: 1000, // for å unngå flere like kall innenfor samme lasting
 	});
 
 export const useSlettSaksbehandler = () => {

--- a/src/client/app/avdelingsleder/AvdelingslederIndex.tsx
+++ b/src/client/app/avdelingsleder/AvdelingslederIndex.tsx
@@ -149,7 +149,6 @@ export const AvdelingslederIndex: FunctionComponent = () => {
 	if (activeAvdelingslederPanel) {
 		return (
 			<div className="max-w-[1400px]">
-				{/* <AvdelingslederContext.Provider value={avdelingslederContextValue}> */}
 				<Row>
 					<BodyShort className={styles.paneltekst}>Avdelingslederpanel</BodyShort>
 				</Row>
@@ -187,7 +186,6 @@ export const AvdelingslederIndex: FunctionComponent = () => {
 						</div>
 					</AvdelingslederDashboard>
 				</Row>
-				{/* </AvdelingslederContext.Provider> */}
 			</div>
 		);
 	}

--- a/src/client/app/avdelingsleder/AvdelingslederIndex.tsx
+++ b/src/client/app/avdelingsleder/AvdelingslederIndex.tsx
@@ -1,6 +1,5 @@
-import React, { FunctionComponent, useEffect, useMemo } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useQuery } from 'react-query';
 import { NavLink } from 'react-router-dom';
 import classnames from 'classnames/bind';
 import { Row } from 'nav-frontend-grid';
@@ -18,11 +17,9 @@ import useTrackRouteParam from 'app/data/trackRouteParam';
 import { avdelingslederTilgangTilNyeKoer } from 'app/envVariablesUtils';
 import NavAnsatt from 'app/navAnsattTsType';
 import { getPanelLocationCreator } from 'app/paths';
-import apiPaths from 'api/apiPaths';
 import { K9LosApiKeys, RestApiGlobalStatePathsKeys } from 'api/k9LosApi';
 import useGlobalStateRestApiData from 'api/rest-api-hooks/src/global-data/useGlobalStateRestApiData';
 import useRestApiRunner from 'api/rest-api-hooks/src/local-data/useRestApiRunner';
-import { Saksbehandler } from 'avdelingsleder/bemanning/saksbehandlerTsType';
 import DagensTallPanel from 'avdelingsleder/dagensTall/DagensTallPanel';
 import ApneBehandlinger from 'avdelingsleder/dagensTall/apneBehandlingerTsType';
 import NokkeltallIndex from 'avdelingsleder/nokkeltall/NokkeltallIndex';
@@ -38,7 +35,6 @@ import BehandlingskoerIndex from './behandlingskoerV3/BehandlingskoerIndex';
 import SaksbehandlereTabell from './bemanning/components/SaksbehandlereTabell';
 import AvdelingslederDashboard from './components/AvdelingslederDashboard';
 import IkkeTilgangTilAvdelingslederPanel from './components/IkkeTilgangTilAvdelingslederPanel';
-import { AvdelingslederContext, AvdelingslederContextState } from './context';
 import ReservasjonerTabell from './reservasjoner/components/ReservasjonerTabellV1';
 
 const classNames = classnames.bind(styles);
@@ -131,19 +127,10 @@ export const AvdelingslederIndex: FunctionComponent = () => {
 		K9LosApiKeys.HENT_DAGENS_TALL,
 	);
 
-	const { data: alleSaksbehandlere, isSuccess } = useQuery<Saksbehandler[]>(apiPaths.hentSaksbehandlereAvdelingsleder);
-
 	useEffect(() => {
 		hentAntallIdag();
 		hentDagensTall();
 	}, []);
-
-	const avdelingslederContextValue = useMemo<AvdelingslederContextState>(
-		() => ({
-			saksbehandlere: isSuccess ? alleSaksbehandlere : [],
-		}),
-		[alleSaksbehandlere],
-	);
 
 	const getPanelFromUrlOrDefault = (loc) => {
 		const panelFromUrl = parseQueryString(loc.search);
@@ -162,49 +149,45 @@ export const AvdelingslederIndex: FunctionComponent = () => {
 	if (activeAvdelingslederPanel) {
 		return (
 			<div className="max-w-[1400px]">
-				<AvdelingslederContext.Provider value={avdelingslederContextValue}>
-					<Row>
-						<BodyShort className={styles.paneltekst}>Avdelingslederpanel</BodyShort>
-					</Row>
-					<Row>
-						<DagensTallPanel totaltIdag={totaltIdag} dagensTall={dagensTall} />
-					</Row>
-					<VerticalSpacer twentyPx />
-					<Row>
-						<AvdelingslederDashboard>
-							<div>
-								<Tabs
-									tabs={[
+				{/* <AvdelingslederContext.Provider value={avdelingslederContextValue}> */}
+				<Row>
+					<BodyShort className={styles.paneltekst}>Avdelingslederpanel</BodyShort>
+				</Row>
+				<Row>
+					<DagensTallPanel totaltIdag={totaltIdag} dagensTall={dagensTall} />
+				</Row>
+				<VerticalSpacer twentyPx />
+				<Row>
+					<AvdelingslederDashboard>
+						<div>
+							<Tabs
+								tabs={[
+									getTab(
+										AvdelingslederPanels.BEHANDLINGSKOER,
+										activeAvdelingslederPanel,
+										getAvdelingslederPanelLocation,
+									),
+									avdelingslederTilgangTilNyeKoer() &&
 										getTab(
-											AvdelingslederPanels.BEHANDLINGSKOER,
+											AvdelingslederPanels.BEHANDLINGSKOER_V3,
 											activeAvdelingslederPanel,
 											getAvdelingslederPanelLocation,
 										),
-										avdelingslederTilgangTilNyeKoer() &&
-											getTab(
-												AvdelingslederPanels.BEHANDLINGSKOER_V3,
-												activeAvdelingslederPanel,
-												getAvdelingslederPanelLocation,
-											),
-										getTab(AvdelingslederPanels.NOKKELTALL, activeAvdelingslederPanel, getAvdelingslederPanelLocation),
-										getTab(AvdelingslederPanels.PROGNOSE, activeAvdelingslederPanel, getAvdelingslederPanelLocation),
-										getTab(
-											AvdelingslederPanels.RESERVASJONER,
-											activeAvdelingslederPanel,
-											getAvdelingslederPanelLocation,
-										),
-										getTab(
-											AvdelingslederPanels.SAKSBEHANDLERE,
-											activeAvdelingslederPanel,
-											getAvdelingslederPanelLocation,
-										),
-									].filter(Boolean)}
-								/>
-								<Panel className={styles.panelPadding}>{renderAvdelingslederPanel(activeAvdelingslederPanel)}</Panel>
-							</div>
-						</AvdelingslederDashboard>
-					</Row>
-				</AvdelingslederContext.Provider>
+									getTab(AvdelingslederPanels.NOKKELTALL, activeAvdelingslederPanel, getAvdelingslederPanelLocation),
+									getTab(AvdelingslederPanels.PROGNOSE, activeAvdelingslederPanel, getAvdelingslederPanelLocation),
+									getTab(AvdelingslederPanels.RESERVASJONER, activeAvdelingslederPanel, getAvdelingslederPanelLocation),
+									getTab(
+										AvdelingslederPanels.SAKSBEHANDLERE,
+										activeAvdelingslederPanel,
+										getAvdelingslederPanelLocation,
+									),
+								].filter(Boolean)}
+							/>
+							<Panel className={styles.panelPadding}>{renderAvdelingslederPanel(activeAvdelingslederPanel)}</Panel>
+						</div>
+					</AvdelingslederDashboard>
+				</Row>
+				{/* </AvdelingslederContext.Provider> */}
 			</div>
 		);
 	}

--- a/src/client/app/avdelingsleder/behandlingskoer/components/oppgavekoForm/UtvalgskriterierForOppgavekoForm.tsx
+++ b/src/client/app/avdelingsleder/behandlingskoer/components/oppgavekoForm/UtvalgskriterierForOppgavekoForm.tsx
@@ -1,13 +1,13 @@
-import React, { FunctionComponent, useContext } from 'react';
+import React, { FunctionComponent } from 'react';
 import { Form } from 'react-final-form';
 import { FormattedMessage, IntlShape, WrappedComponentProps, injectIntl } from 'react-intl';
 import { TrashIcon } from '@navikt/aksel-icons';
 import { BodyShort, Button } from '@navikt/ds-react';
 import { K9LosApiKeys } from 'api/k9LosApi';
+import { useHentSaksbehandlereAvdelingsleder } from 'api/queries/avdelingslederQueries';
 import useRestApiRunner from 'api/rest-api-hooks/src/local-data/useRestApiRunner';
 import SkjermetVelger from 'avdelingsleder/behandlingskoer/components/oppgavekoForm/SkjermetVelger';
 import SaksbehandlereForOppgavekoForm from 'avdelingsleder/behandlingskoer/components/saksbehandlerForm/SaksbehandlereForOppgavekoForm';
-import { AvdelingslederContext } from 'avdelingsleder/context';
 import { InputField } from 'form/FinalFields';
 import kodeverkTyper from 'kodeverk/kodeverkTyper';
 import { hasValidName, maxLength, minLength, required } from 'utils/validation/validators';
@@ -85,7 +85,7 @@ export const UtvalgskriterierForOppgavekoForm: FunctionComponent<OwnProps & Wrap
 			.then(() => hentKo(values.id));
 	};
 
-	const { saksbehandlere: alleSaksbehandlere } = useContext(AvdelingslederContext);
+	const { data: alleSaksbehandlere } = useHentSaksbehandlereAvdelingsleder();
 
 	return (
 		<div className={styles.form}>

--- a/src/client/app/avdelingsleder/behandlingskoerV3/BehandlingsKoForm.tsx
+++ b/src/client/app/avdelingsleder/behandlingskoerV3/BehandlingsKoForm.tsx
@@ -8,7 +8,6 @@ import { required } from '@navikt/ft-form-validators';
 import AppContext from 'app/AppContext';
 import { useHentSaksbehandlereAvdelingsleder, useKo, useOppdaterKøMutation } from 'api/queries/avdelingslederQueries';
 import { Saksbehandler } from 'avdelingsleder/bemanning/saksbehandlerTsType';
-import { AvdelingslederContext } from 'avdelingsleder/context';
 import FilterIndex from 'filter/FilterIndex';
 import { OppgaveQuery, OppgavefilterKode } from 'filter/filterTsTypes';
 import SearchWithDropdown from 'sharedComponents/searchWithDropdown/SearchWithDropdown';
@@ -233,9 +232,9 @@ const BehandlingsKoForm = ({ kø, lukk, ekspandert, id }: BehandlingsKoFormProps
 
 const BehandlingsKoFormContainer = (props: BaseProps) => {
 	const { lukk, ekspandert, id } = props;
-	const { data, isLoading, error } = useKo(props.id, { enabled: ekspandert });
+	const { data, isFetching, error } = useKo(props.id, { enabled: ekspandert });
 
-	if (isLoading) {
+	if (isFetching) {
 		return <div className="animate-pulse bg-surface-neutral-subtle h-10 w-full rounded-xl" />;
 	}
 
@@ -243,7 +242,7 @@ const BehandlingsKoFormContainer = (props: BaseProps) => {
 		return <ErrorMessage>Noe gikk galt ved henting av kø</ErrorMessage>;
 	}
 
-	if (!data) return null;
+	if (!data || !ekspandert) return null;
 
 	return <BehandlingsKoForm kø={data} id={id} lukk={lukk} ekspandert={ekspandert} />;
 };

--- a/src/client/app/avdelingsleder/behandlingskoerV3/BehandlingsKoForm.tsx
+++ b/src/client/app/avdelingsleder/behandlingskoerV3/BehandlingsKoForm.tsx
@@ -6,7 +6,7 @@ import { Alert, Button, ErrorMessage, Heading, Label, Modal } from '@navikt/ds-r
 import { Form, InputField, TextAreaField } from '@navikt/ft-form-hooks';
 import { required } from '@navikt/ft-form-validators';
 import AppContext from 'app/AppContext';
-import { useKo, useOppdaterKøMutation } from 'api/queries/avdelingslederQueries';
+import { useHentSaksbehandlereAvdelingsleder, useKo, useOppdaterKøMutation } from 'api/queries/avdelingslederQueries';
 import { Saksbehandler } from 'avdelingsleder/bemanning/saksbehandlerTsType';
 import { AvdelingslederContext } from 'avdelingsleder/context';
 import FilterIndex from 'filter/FilterIndex';
@@ -53,7 +53,7 @@ const BehandlingsKoForm = ({ kø, lukk, ekspandert, id }: BehandlingsKoFormProps
 	const { versjon } = kø;
 	const [visFilterModal, setVisFilterModal] = useState(false);
 	const [visSuksess, setVisSuksess] = useState(false);
-	const { saksbehandlere: alleSaksbehandlere } = useContext(AvdelingslederContext);
+	const { data: alleSaksbehandlere } = useHentSaksbehandlereAvdelingsleder();
 	const defaultValues = {
 		[fieldnames.TITTEL]: kø?.tittel || '',
 		[fieldnames.SAKSBEHANDLERE]: kø?.saksbehandlere || [],

--- a/src/client/app/avdelingsleder/bemanning/components/LeggTilSaksbehandlerForm.tsx
+++ b/src/client/app/avdelingsleder/bemanning/components/LeggTilSaksbehandlerForm.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useContext, useState } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import { Field, FieldMetaState, Form } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 import { useQueryClient } from 'react-query';
@@ -9,7 +9,6 @@ import apiPaths from 'api/apiPaths';
 import { K9LosApiKeys } from 'api/k9LosApi';
 import { useHentSaksbehandlereAvdelingsleder } from 'api/queries/avdelingslederQueries';
 import useRestApiRunner from 'api/rest-api-hooks/src/local-data/useRestApiRunner';
-import { AvdelingslederContext } from 'avdelingsleder/context';
 import VerticalSpacer from 'sharedComponents/VerticalSpacer';
 import { hasValidEmailFormat } from 'utils/validation/validators';
 import { Saksbehandler } from '../saksbehandlerTsType';

--- a/src/client/app/avdelingsleder/bemanning/components/LeggTilSaksbehandlerForm.tsx
+++ b/src/client/app/avdelingsleder/bemanning/components/LeggTilSaksbehandlerForm.tsx
@@ -7,6 +7,7 @@ import { Button, Label, TextField } from '@navikt/ds-react';
 import { PlusIcon } from '@navikt/ft-plattform-komponenter';
 import apiPaths from 'api/apiPaths';
 import { K9LosApiKeys } from 'api/k9LosApi';
+import { useHentSaksbehandlereAvdelingsleder } from 'api/queries/avdelingslederQueries';
 import useRestApiRunner from 'api/rest-api-hooks/src/local-data/useRestApiRunner';
 import { AvdelingslederContext } from 'avdelingsleder/context';
 import VerticalSpacer from 'sharedComponents/VerticalSpacer';
@@ -18,7 +19,7 @@ import { Saksbehandler } from '../saksbehandlerTsType';
  */
 export const LeggTilSaksbehandlerForm: FunctionComponent = () => {
 	const [finnesAllerede, setFinnesAllerede] = useState(false);
-	const { saksbehandlere } = useContext(AvdelingslederContext);
+	const { data: saksbehandlere } = useHentSaksbehandlereAvdelingsleder();
 	const queryClient = useQueryClient();
 
 	const { startRequest: leggTilSaksbehandler, resetRequestData: resetSaksbehandlerSok } =

--- a/src/client/app/avdelingsleder/bemanning/components/SaksbehandlerInfo.tsx
+++ b/src/client/app/avdelingsleder/bemanning/components/SaksbehandlerInfo.tsx
@@ -4,6 +4,7 @@ import { TrashIcon } from '@navikt/aksel-icons';
 import { BodyShort, Button } from '@navikt/ds-react';
 import apiPaths from 'api/apiPaths';
 import { K9LosApiKeys } from 'api/k9LosApi';
+import { useSlettSaksbehandler } from 'api/queries/avdelingslederQueries';
 import { useRestApiRunner } from 'api/rest-api-hooks';
 import SletteSaksbehandlerModal from 'avdelingsleder/bemanning/components/SletteSaksbehandlerModal';
 import { Saksbehandler } from 'avdelingsleder/bemanning/saksbehandlerTsType';
@@ -19,14 +20,8 @@ const SaksbehandlerInfo: FunctionComponent<OwnProps> = ({ saksbehandler }) => {
 		setVisSlettModal(false);
 	};
 
-	const queryClient = useQueryClient();
-
-	const { startRequest: fjernSaksbehandler } = useRestApiRunner<Saksbehandler>(K9LosApiKeys.SLETT_SAKSBEHANDLER);
-	const fjernSaksbehandlerFn = (epost: string) =>
-		fjernSaksbehandler({ epost }).then(() => {
-			queryClient.invalidateQueries({ queryKey: apiPaths.hentSaksbehandlereAvdelingsleder });
-			lukkSlettModal();
-		});
+	const { mutate } = useSlettSaksbehandler();
+	const slettSaksbehandler = () => mutate({ epost: saksbehandler.epost }, { onSuccess: lukkSlettModal });
 
 	return (
 		<div>
@@ -53,7 +48,7 @@ const SaksbehandlerInfo: FunctionComponent<OwnProps> = ({ saksbehandler }) => {
 				<SletteSaksbehandlerModal
 					valgtSaksbehandler={saksbehandler}
 					closeSletteModal={lukkSlettModal}
-					fjernSaksbehandler={fjernSaksbehandlerFn}
+					slettSaksbehandler={slettSaksbehandler}
 				/>
 			)}
 		</div>

--- a/src/client/app/avdelingsleder/bemanning/components/SaksbehandlereTabell.tsx
+++ b/src/client/app/avdelingsleder/bemanning/components/SaksbehandlereTabell.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, useContext } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { BodyShort, Table } from '@navikt/ds-react';
+import { useHentSaksbehandlereAvdelingsleder } from 'api/queries/avdelingslederQueries';
 import LeggTilSaksbehandlerForm from 'avdelingsleder/bemanning/components/LeggTilSaksbehandlerForm';
 import SaksbehandlerInfo from 'avdelingsleder/bemanning/components/SaksbehandlerInfo';
 import { AvdelingslederContext } from 'avdelingsleder/context';
@@ -11,7 +12,11 @@ import VerticalSpacer from 'sharedComponents/VerticalSpacer';
  */
 
 const SaksbehandlereTabell: FunctionComponent = () => {
-	const { saksbehandlere } = useContext(AvdelingslederContext);
+	const { data: saksbehandlere, isSuccess } = useHentSaksbehandlereAvdelingsleder();
+
+	if (!isSuccess) {
+		return null;
+	}
 
 	return (
 		<>

--- a/src/client/app/avdelingsleder/bemanning/components/SletteSaksbehandlerModal.tsx
+++ b/src/client/app/avdelingsleder/bemanning/components/SletteSaksbehandlerModal.tsx
@@ -1,12 +1,12 @@
 import React, { FunctionComponent } from 'react';
+import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
 import { BodyLong, Button, Modal } from '@navikt/ds-react';
 import { Saksbehandler } from '../saksbehandlerTsType';
-import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
 
 type OwnProps = Readonly<{
 	valgtSaksbehandler: Saksbehandler;
 	closeSletteModal: () => void;
-	fjernSaksbehandler: (epost: string) => void;
+	slettSaksbehandler: (epost: string) => void;
 }>;
 
 /**
@@ -17,30 +17,28 @@ type OwnProps = Readonly<{
 const SletteSaksbehandlerModal: FunctionComponent<OwnProps> = ({
 	valgtSaksbehandler,
 	closeSletteModal,
-	fjernSaksbehandler,
+	slettSaksbehandler,
 }) => (
-	<>
-		<Modal
-			header={{ heading: 'Ønsker du å slette saksbehandler?', icon: <ExclamationmarkTriangleIcon /> }}
-			onClose={closeSletteModal}
-			className="min-w-[500px]"
-			open
-		>
-			<Modal.Body>
-				<BodyLong>
-					{`Er du sikker på at du vil slette ${
-						valgtSaksbehandler.navn || valgtSaksbehandler.epost
-					}? Saksbehandleren kan fortsatt logge inn i K9Los og søke opp oppgaver, men vil ikke kunne reservere oppgaver eller legges til i køer.`}
-				</BodyLong>
-			</Modal.Body>
-			<Modal.Footer>
-				<Button onClick={() => fjernSaksbehandler(valgtSaksbehandler.epost)}>Ja</Button>
-				<Button variant="secondary" onClick={closeSletteModal}>
-					Nei
-				</Button>
-			</Modal.Footer>
-		</Modal>
-	</>
+	<Modal
+		header={{ heading: 'Ønsker du å slette saksbehandler?', icon: <ExclamationmarkTriangleIcon /> }}
+		onClose={closeSletteModal}
+		className="min-w-[500px]"
+		open
+	>
+		<Modal.Body>
+			<BodyLong>
+				{`Er du sikker på at du vil slette ${
+					valgtSaksbehandler.navn || valgtSaksbehandler.epost
+				}? Saksbehandleren kan fortsatt logge inn i K9Los og søke opp oppgaver, men vil ikke kunne reservere oppgaver eller legges til i køer.`}
+			</BodyLong>
+		</Modal.Body>
+		<Modal.Footer>
+			<Button onClick={() => slettSaksbehandler(valgtSaksbehandler.epost)}>Ja</Button>
+			<Button variant="secondary" onClick={closeSletteModal}>
+				Nei
+			</Button>
+		</Modal.Footer>
+	</Modal>
 );
 
 export default SletteSaksbehandlerModal;

--- a/src/client/app/avdelingsleder/context.tsx
+++ b/src/client/app/avdelingsleder/context.tsx
@@ -1,8 +1,0 @@
-import { createContext } from 'react';
-import { Saksbehandler } from './bemanning/saksbehandlerTsType';
-
-export type AvdelingslederContextState = { saksbehandlere: Saksbehandler[] };
-
-export const AvdelingslederContext = createContext<AvdelingslederContextState>({
-	saksbehandlere: [],
-});

--- a/src/client/app/filter/parts/testdata.ts
+++ b/src/client/app/filter/parts/testdata.ts
@@ -2027,6 +2027,10 @@ export const felter = [
 					'En annen sak tilknyttet barnet må behandles frem til uttak, eller besluttes, før denne saken kan behandles videre.',
 			},
 			{
+				verdi: '9291',
+				visningsnavn: 'Vurder hvilken dato ny regel for utbetalingsgrad i uttak skal gjelde fra.',
+			},
+			{
 				verdi: '9300',
 				visningsnavn: 'Vurder om institusjonen er godkjent',
 			},


### PR DESCRIPTION
Bug:
![slett-saksbehandler-bug](https://github.com/user-attachments/assets/60879f02-8a45-4fb9-949b-fed1341f3c1c)
Årsaken til buggen er at det etter sletting ikke er samsvar mellom:
 1) lista med alle saksbehandlere (epost, navn, etc)
 2) oppgavekøens saksbehandlere

Løsning:
Rendrer ikke komponenten dersom raden for oppgavekøen ikke er ekspandert. Ved ekspandering løses problemet ved ny fetching av data.