### PR TITLE
Selv om leggTilBehandletOppgave feiler så åpnes oppgaven i fagsystem

### DIFF
--- a/src/client/app/app/paths.tsx
+++ b/src/client/app/app/paths.tsx
@@ -24,7 +24,7 @@ export const getPanelLocationCreator = (location: Location) => (avdelingslederPa
 export const getPanelLocationCreatorDriftsmeldinger = (location: Location) => (adminPanel: string) =>
 	getLocationWithQueryParams(location, { fane: adminPanel });
 
-export const getK9sakHref = (k9sakUrl: string, saksnummer: string, behandlingId?: number) => {
+export const getK9sakHref = (k9sakUrl: string, saksnummer: string, behandlingId?: string) => {
 	const reducer = (previousValue, param) => (param.include ? { ...previousValue, ...param.query } : previousValue);
 	const queryParams = [
 		{ include: behandlingId, query: { fakta: 'default' } },

--- a/src/client/app/saksbehandler/behandlingskoer/BehandlingskoerIndex.tsx
+++ b/src/client/app/saksbehandler/behandlingskoer/BehandlingskoerIndex.tsx
@@ -1,15 +1,15 @@
 import React, { FunctionComponent, useCallback, useMemo, useState } from 'react';
 import { WrappedComponentProps, injectIntl } from 'react-intl';
-import { saksbehandlerKanVelgeNyeKoer } from 'app/envVariablesUtils';
-import { OppgavekøV3, OppgavekøV3MedNavn } from 'types/OppgavekøV3Type';
-import { getK9punsjRef, getK9sakHref } from 'app/paths';
 import { Loader } from '@navikt/ds-react';
+import { saksbehandlerKanVelgeNyeKoer } from 'app/envVariablesUtils';
+import { getK9punsjRef, getK9sakHref } from 'app/paths';
 import { K9LosApiKeys } from 'api/k9LosApi';
 import { useAlleSaksbehandlerKoerV1, useAlleSaksbehandlerKoerV3 } from 'api/queries/saksbehandlerQueries';
 import useRestApiRunner from 'api/rest-api-hooks/src/local-data/useRestApiRunner';
 import BehandlingskoerContext from 'saksbehandler/BehandlingskoerContext';
 import { OppgavekøV1 } from 'saksbehandler/behandlingskoer/oppgavekoTsType';
 import Oppgave from 'saksbehandler/oppgaveTsType';
+import { OppgavekøV3, OppgavekøV3MedNavn } from 'types/OppgavekøV3Type';
 import OppgaveSystem from '../../types/OppgaveSystem';
 import OppgavekoPanel from './components/OppgavekoPanel';
 
@@ -36,7 +36,7 @@ const BehandlingskoerIndex: FunctionComponent<OwnProps & WrappedComponentProps> 
 	const { startRequest: leggTilBehandletOppgave } = useRestApiRunner(K9LosApiKeys.LEGG_TIL_BEHANDLET_OPPGAVE);
 
 	const openFagsak = (oppgave: Oppgave) => {
-		leggTilBehandletOppgave(oppgave.oppgaveNøkkel).then(() => {
+		leggTilBehandletOppgave(oppgave.oppgaveNøkkel).finally(() => {
 			switch (oppgave.system) {
 				case OppgaveSystem.PUNSJ:
 					window.location.assign(getK9punsjRef(k9punsjUrl, oppgave.journalpostId));

--- a/src/client/app/saksbehandler/behandlingskoer/components/OppgavekoPanel.tsx
+++ b/src/client/app/saksbehandler/behandlingskoer/components/OppgavekoPanel.tsx
@@ -34,12 +34,12 @@ const OppgavekoPanel: FunctionComponent<OwnProps> = ({ apneOppgave }) => {
 		resetRequestData,
 	} = useRestApiRunner<Oppgave>(K9LosApiKeys.FÅ_OPPGAVE_FRA_KO);
 	const { mutateAsync: leggTilSisteOppgaver } = useSisteOppgaverMutation();
-	const { mutate } = usePlukkOppgaveMutation(async (reservasjoner) => {
+	const { mutate } = usePlukkOppgaveMutation((reservasjoner) => {
 		if (reservasjoner.length > 0) {
 			const { oppgaveNøkkelDto, oppgavebehandlingsUrl } = reservasjoner[0];
-			await leggTilBehandletOppgave(oppgaveNøkkelDto);
-			await leggTilSisteOppgaver(oppgaveNøkkelDto);
-			window.location.assign(oppgavebehandlingsUrl);
+			Promise.all([leggTilBehandletOppgave(oppgaveNøkkelDto), leggTilSisteOppgaver(oppgaveNøkkelDto)]).finally(() =>
+				window.location.assign(oppgavebehandlingsUrl),
+			);
 		} else {
 			setVisFinnesIngenBehandlingerIKoModal(true);
 		}

--- a/src/client/app/saksbehandler/behandlingskoer/components/oppgavetabeller/ReservertOppgaveRadV3.tsx
+++ b/src/client/app/saksbehandler/behandlingskoer/components/oppgavetabeller/ReservertOppgaveRadV3.tsx
@@ -57,15 +57,17 @@ const ReservertOppgaveRadV3: React.ForwardRefExoticComponent<Props> = React.forw
 		};
 
 		const tilOppgave = async () => {
-			await leggTilBehandletOppgave(oppgave.oppgaveNøkkel);
-			await leggTilSisteOppgaver(oppgave.oppgaveNøkkel);
+			Promise.all([
+				leggTilBehandletOppgave(oppgave.oppgaveNøkkel),
+				leggTilSisteOppgaver(oppgave.oppgaveNøkkel),
+			]).finally(() => {
+				let fallbackUrl = '';
 
-			let fallbackUrl = '';
-
-			if (oppgave?.saksnummer) {
-				fallbackUrl = getK9sakHref(k9sakUrl.verdi, oppgave?.saksnummer, oppgave?.oppgaveNøkkel?.oppgaveEksternId);
-			}
-			window.location.assign(oppgave.oppgavebehandlingsUrl || fallbackUrl);
+				if (oppgave?.saksnummer) {
+					fallbackUrl = getK9sakHref(k9sakUrl.verdi, oppgave?.saksnummer, oppgave?.oppgaveNøkkel?.oppgaveEksternId);
+				}
+				window.location.assign(oppgave.oppgavebehandlingsUrl || fallbackUrl);
+			});
 		};
 		return (
 			<Table.Row

--- a/src/client/app/saksbehandler/behandlingskoer/components/oppgavetabeller/ReserverteOppgaverTabell.tsx
+++ b/src/client/app/saksbehandler/behandlingskoer/components/oppgavetabeller/ReserverteOppgaverTabell.tsx
@@ -57,15 +57,14 @@ const ReserverteOppgaverTabell: FunctionComponent<OwnProps> = ({ apneOppgave, gj
 	const forlengOppgaveReservasjonFn = (oppgaveNøkkel: OppgaveNøkkel) => {
 		forlengOppgavereservasjon({ oppgaveNøkkel }).then(() => {
 			queryClient.invalidateQueries({
-                queryKey: [apiPaths.saksbehandlerReservasjoner]
-            });
+				queryKey: [apiPaths.saksbehandlerReservasjoner],
+			});
 		});
 	};
 	const ref = useRef({});
 
 	const goToFagsak = (oppgave: Oppgave) => {
-		leggTilBehandletOppgave(oppgave.oppgaveNøkkel);
-		apneOppgave(oppgave);
+		leggTilBehandletOppgave(oppgave.oppgaveNøkkel).finally(() => apneOppgave(oppgave));
 	};
 
 	const countReservations = (reservasjon: ReservasjonV3) => {

--- a/src/client/app/saksbehandler/fagsakSearch/FagsakSearchIndex.tsx
+++ b/src/client/app/saksbehandler/fagsakSearch/FagsakSearchIndex.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useState } from 'react';
+import { getK9punsjRef, getK9sakHref } from 'app/paths';
 import { K9LosApiKeys } from 'api/k9LosApi';
 import { useRestApiRunner } from 'api/rest-api-hooks';
-import { getK9punsjRef, getK9sakHref } from 'app/paths';
 import ValgtOppgaveModal from 'saksbehandler/components/ValgtOppgaveModal';
 import Oppgave from 'saksbehandler/oppgaveTsType';
 import OppgaveSystem from '../../types/OppgaveSystem';
@@ -25,7 +25,7 @@ const FagsakSearchIndex: FunctionComponent<OwnProps> = ({ k9sakUrl, k9punsjUrl }
 	const { startRequest: leggTilBehandletOppgave } = useRestApiRunner(K9LosApiKeys.LEGG_TIL_BEHANDLET_OPPGAVE);
 
 	const goToFagsak = (oppgave: Oppgave) => {
-		leggTilBehandletOppgave(oppgave.oppgaveNøkkel).then(() => {
+		leggTilBehandletOppgave(oppgave.oppgaveNøkkel).finally(() => {
 			switch (oppgave.system) {
 				case OppgaveSystem.K9SAK:
 					window.location.assign(getK9sakHref(k9sakUrl, oppgave.saksnummer, oppgave.behandlingId));


### PR DESCRIPTION
### **Behov / Bakgrunn**
Hvis man prøver å åpne en oppgave der API-kall til /legg-til-behandlet-sak har feilet, da vil man i dagens løsning ikke komme videre. Dette har skjedd i et tilfelle der punsjoppgave er journalført på feil aktør.

### **Løsning**
Siden dette er ikke-kritisk funksjonalitet i LOS sendes bruker videre både ved suksess og feil.

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
